### PR TITLE
Manually specify global settings agentVsn in terraform provider

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/hashicorp/terraform-plugin-framework-validators v0.12.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/pluralsh/console-client-go v0.4.0
+	github.com/pluralsh/console-client-go v0.5.3
 	github.com/pluralsh/plural-cli v0.8.5-0.20240216094552-efc34ee6de37
 	github.com/pluralsh/polly v0.1.7
 	github.com/samber/lo v1.38.1

--- a/go.sum
+++ b/go.sum
@@ -858,6 +858,8 @@ github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZ
 github.com/pkg/sftp v1.13.1/go.mod h1:3HaPG6Dq1ILlpPZRO0HVMrsydcdLt6HRDccSgb87qRg=
 github.com/pluralsh/console-client-go v0.4.0 h1:lgKaVGi8jB7S8wFF6L3P6H/4Xc88e4FozhyW58O1w3Q=
 github.com/pluralsh/console-client-go v0.4.0/go.mod h1:eyCiLA44YbXiYyJh8303jk5JdPkt9McgCo5kBjk4lKo=
+github.com/pluralsh/console-client-go v0.5.3 h1:RB4XtKlvh8+BM5o1o0h+W6zHculBGbL6q5lI/yRnqJE=
+github.com/pluralsh/console-client-go v0.5.3/go.mod h1:eyCiLA44YbXiYyJh8303jk5JdPkt9McgCo5kBjk4lKo=
 github.com/pluralsh/gqlclient v1.11.0 h1:FfXW7FiEJLHOfTAa7NxDb8jb3aMZNIpCAcG+bg8uHYA=
 github.com/pluralsh/gqlclient v1.11.0/go.mod h1:qSXKUlio1F2DRPy8el4oFYsmpKbkUYspgPB87T4it5I=
 github.com/pluralsh/plural-cli v0.8.5-0.20240216094552-efc34ee6de37 h1:DBnaKvKmbTbKwbkrh/2gJBwyHYfaXdxeT3UGh+94K4g=

--- a/internal/resource/cluster_model.go
+++ b/internal/resource/cluster_model.go
@@ -90,6 +90,8 @@ func (c *cluster) UpdateAttributes(ctx context.Context, d diag.Diagnostics) cons
 		Handle:    c.Handle.ValueStringPointer(),
 		Protect:   c.Protect.ValueBoolPointer(),
 		NodePools: c.NodePoolsAttribute(ctx, d),
+		Metadata:  c.Metadata.ValueStringPointer(),
+		Tags:      c.TagsAttribute(ctx, d),
 	}
 }
 

--- a/internal/resource/infrastructure_stack_model.go
+++ b/internal/resource/infrastructure_stack_model.go
@@ -276,7 +276,7 @@ func (isjs *InfrastructureStackJobSpec) ContainersAttributes(ctx context.Context
 	return result
 }
 
-func (isjs *InfrastructureStackJobSpec) From(spec *gqlclient.JobGateSpecFragment, ctx context.Context, d diag.Diagnostics) {
+func (isjs *InfrastructureStackJobSpec) From(spec *gqlclient.JobSpecFragment, ctx context.Context, d diag.Diagnostics) {
 	if isjs == nil {
 		return
 	}

--- a/internal/resource/service_deployment_schema.go
+++ b/internal/resource/service_deployment_schema.go
@@ -97,24 +97,24 @@ func (r *ServiceDeploymentResource) schemaKustomize() schema.SingleNestedAttribu
 	}
 }
 
-func (r *ServiceDeploymentResource) schemaConfiguration() schema.SetNestedAttribute {
-	return schema.SetNestedAttribute{
-		Optional:            true,
-		Description:         "List of [name, value] secrets used to alter this ServiceDeployment configuration.",
-		MarkdownDescription: "List of [name, value] secrets used to alter this ServiceDeployment configuration.",
-		NestedObject: schema.NestedAttributeObject{
-			Attributes: map[string]schema.Attribute{
-				"name": schema.StringAttribute{
-					Required: true,
-				},
-				"value": schema.StringAttribute{
-					Required:  true,
-					Sensitive: true,
-				},
-			},
-		},
-	}
-}
+// func (r *ServiceDeploymentResource) schemaConfiguration() schema.SetNestedAttribute {
+// 	return schema.SetNestedAttribute{
+// 		Optional:            true,
+// 		Description:         "List of [name, value] secrets used to alter this ServiceDeployment configuration.",
+// 		MarkdownDescription: "List of [name, value] secrets used to alter this ServiceDeployment configuration.",
+// 		NestedObject: schema.NestedAttributeObject{
+// 			Attributes: map[string]schema.Attribute{
+// 				"name": schema.StringAttribute{
+// 					Required: true,
+// 				},
+// 				"value": schema.StringAttribute{
+// 					Required:  true,
+// 					Sensitive: true,
+// 				},
+// 			},
+// 		},
+// 	}
+// }
 
 func (r *ServiceDeploymentResource) schemaCluster() schema.SingleNestedAttribute {
 	return schema.SingleNestedAttribute{


### PR DESCRIPTION
This should allow the console api to specify the exact agent version as needed so installs remain properly backwards compatible.