### PR TITLE
Fix plan modifier for cluster project id

### DIFF
--- a/internal/resource/cluster_schema.go
+++ b/internal/resource/cluster_schema.go
@@ -51,7 +51,7 @@ func (r *clusterResource) schema() schema.Schema {
 				MarkdownDescription: "ID of the project that this cluster belongs to.",
 				Computed:            true,
 				Optional:            true,
-				PlanModifiers:       []planmodifier.String{stringplanmodifier.RequiresReplace()},
+				// PlanModifiers:       []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},
 			"detach": schema.BoolAttribute{
 				Description:         "Determines behavior during resource destruction, if true it will detach resource instead of deleting it.",


### PR DESCRIPTION
We shouldn't delete the cluster for this (mostly because it causes too much disruption).