### PR TITLE
Don't make project id computed

### DIFF
--- a/internal/resource/cluster_schema.go
+++ b/internal/resource/cluster_schema.go
@@ -49,7 +49,7 @@ func (r *clusterResource) schema() schema.Schema {
 			"project_id": schema.StringAttribute{
 				Description:         "ID of the project that this cluster belongs to.",
 				MarkdownDescription: "ID of the project that this cluster belongs to.",
-				Computed:            true,
+				Computed:            false,
 				Optional:            true,
 				// PlanModifiers:       []planmodifier.String{stringplanmodifier.RequiresReplace()},
 			},


### PR DESCRIPTION
this also borks annoyingly, the core thing we're trying to avoid is having a detected upstream project id causing a full replacement of the cluster resource