### PR TITLE
enhancement: Implement missing import state functions

### DIFF
--- a/internal/resource/group_member.go
+++ b/internal/resource/group_member.go
@@ -122,8 +122,6 @@ func (r *GroupMemberResource) Delete(ctx context.Context, req resource.DeleteReq
 	}
 }
 
-func (r *GroupMemberResource) ImportState(
-	ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse,
-) {
+func (r *GroupMemberResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }

--- a/internal/resource/stack_run_trigger.go
+++ b/internal/resource/stack_run_trigger.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -115,4 +116,8 @@ func (in *stackRunTriggerResource) Update(ctx context.Context, req resource.Upda
 
 func (in *stackRunTriggerResource) Delete(_ context.Context, _ resource.DeleteRequest, _ *resource.DeleteResponse) {
 	// Since this is only a trigger, there is no delete API. Ignore.
+}
+
+func (in *stackRunTriggerResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }


### PR DESCRIPTION
Implemented `ImportState` function for `plural_pr_automation_trigger` and `plural_stack_run_trigger` resources. `plural_pr_automation_trigger` will use `pr_automation_id,pr_automation_branch` as import identifier and `plural_stack_run_trigger` will use `id` (stack ID).

Resources mentioned above are write-only (`Read` function is empty) just like `plural_rbac` however we can implement import to avoid errors like the one from the ticket. Import requires providing all required fields from config as we cannot read them from anywhere.

[Related docs](https://developer.hashicorp.com/terraform/plugin/framework/resources/import). 