### PR TITLE
fix: resource read should remove from state on resource not found

### DIFF
--- a/example/servicecontext/main.tf
+++ b/example/servicecontext/main.tf
@@ -26,6 +26,6 @@ resource "plural_service_context" "service_context" {
   }
 }
 
-data "plural_service_context" "service_context" {
-  name = plural_service_context.service_context.name
-}
+# data "plural_service_context" "service_context" {
+#   name = plural_service_context.service_context.name
+# }

--- a/example/servicecontext/main.tf
+++ b/example/servicecontext/main.tf
@@ -26,6 +26,6 @@ resource "plural_service_context" "service_context" {
   }
 }
 
-# data "plural_service_context" "service_context" {
-#   name = plural_service_context.service_context.name
-# }
+data "plural_service_context" "service_context" {
+  name = plural_service_context.service_context.name
+}

--- a/internal/resource/cloud_connection.go
+++ b/internal/resource/cloud_connection.go
@@ -163,6 +163,11 @@ func (r *CloudConnectionResource) Read(ctx context.Context, req resource.ReadReq
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read cloud connection, got error: %s", err))
 		return
 	}
+	if response == nil || response.CloudConnection == nil {
+		// Resource not found, remove from state
+		resp.State.RemoveResource(ctx)
+		return
+	}
 
 	data.From(response.CloudConnection, ctx, &resp.Diagnostics)
 	resp.Diagnostics.Append(resp.State.Set(ctx, data)...)

--- a/internal/resource/cluster.go
+++ b/internal/resource/cluster.go
@@ -98,7 +98,8 @@ func (r *clusterResource) Read(ctx context.Context, req resource.ReadRequest, re
 		return
 	}
 	if result == nil || result.Cluster == nil {
-		resp.Diagnostics.AddError("Not Found", "Unable to find cluster, it looks like it was deleted manually")
+		// Resource not found, remove from state
+		resp.State.RemoveResource(ctx)
 		return
 	}
 

--- a/internal/resource/git_repository.go
+++ b/internal/resource/git_repository.go
@@ -173,9 +173,9 @@ func (r *GitRepositoryResource) Read(ctx context.Context, req resource.ReadReque
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to get GitRepository, got error: %s", err))
 		return
 	}
-
 	if response == nil || response.GitRepository == nil {
-		resp.Diagnostics.AddError("Client Error", "Unable to find GitRepository")
+		// Resource not found, remove from state
+		resp.State.RemoveResource(ctx)
 		return
 	}
 

--- a/internal/resource/group.go
+++ b/internal/resource/group.go
@@ -115,9 +115,9 @@ func (r *GroupResource) Read(ctx context.Context, req resource.ReadRequest, resp
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to get group, got error: %s", err))
 		return
 	}
-
 	if response == nil || response.Group == nil {
-		resp.Diagnostics.AddError("Client Error", "Unable to find group")
+		// Resource not found, remove from state
+		resp.State.RemoveResource(ctx)
 		return
 	}
 

--- a/internal/resource/infrastructure_stack.go
+++ b/internal/resource/infrastructure_stack.go
@@ -86,6 +86,11 @@ func (r *InfrastructureStackResource) Read(ctx context.Context, req resource.Rea
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read infrastructure stack, got error: %s", err))
 		return
 	}
+	if response == nil || response.InfrastructureStack == nil {
+		// Resource not found, remove from state
+		resp.State.RemoveResource(ctx)
+		return
+	}
 
 	data.From(response.InfrastructureStack, ctx, &resp.Diagnostics)
 	resp.Diagnostics.Append(resp.State.Set(ctx, data)...)

--- a/internal/resource/observability_webhook.go
+++ b/internal/resource/observability_webhook.go
@@ -126,7 +126,8 @@ func (r *ObservabilityWebhookResource) Read(ctx context.Context, req resource.Re
 		return
 	}
 	if response.ObservabilityWebhook == nil {
-		resp.Diagnostics.AddError("Client Error", "Unable to find observability webhook, got no error")
+		// Resource not found, remove from state
+		resp.State.RemoveResource(ctx)
 		return
 	}
 

--- a/internal/resource/observability_webhook.go
+++ b/internal/resource/observability_webhook.go
@@ -125,7 +125,7 @@ func (r *ObservabilityWebhookResource) Read(ctx context.Context, req resource.Re
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read observability webhook, got error: %s", err))
 		return
 	}
-	if response.ObservabilityWebhook == nil {
+	if response == nil || response.ObservabilityWebhook == nil {
 		// Resource not found, remove from state
 		resp.State.RemoveResource(ctx)
 		return

--- a/internal/resource/project.go
+++ b/internal/resource/project.go
@@ -158,6 +158,11 @@ func (r *ProjectResource) Read(ctx context.Context, req resource.ReadRequest, re
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read project, got error: %s", err))
 		return
 	}
+	if response == nil || response.Project == nil {
+		// Resource not found, remove from state
+		resp.State.RemoveResource(ctx)
+		return
+	}
 
 	data.From(response.Project, ctx, &resp.Diagnostics)
 	resp.Diagnostics.Append(resp.State.Set(ctx, data)...)

--- a/internal/resource/provider.go
+++ b/internal/resource/provider.go
@@ -227,7 +227,8 @@ func (r *providerResource) Read(ctx context.Context, req resource.ReadRequest, r
 		return
 	}
 	if result == nil || result.ClusterProvider == nil {
-		resp.Diagnostics.AddError("Not Found", "Unable to find provider, it looks like it was deleted manually")
+		// Resource not found, remove from state
+		resp.State.RemoveResource(ctx)
 		return
 	}
 

--- a/internal/resource/scm_webhook.go
+++ b/internal/resource/scm_webhook.go
@@ -131,8 +131,9 @@ func (r *SCMWebhookResource) Read(ctx context.Context, req resource.ReadRequest,
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read SCM webhook, got error: %s", err))
 		return
 	}
-	if response.ScmWebhook == nil {
-		resp.Diagnostics.AddError("Client Error", "Unable to find SCM webhook, got no error")
+	if response == nil || response.ScmWebhook == nil {
+		// Resource not found, remove from state
+		resp.State.RemoveResource(ctx)
 		return
 	}
 

--- a/internal/resource/service_context.go
+++ b/internal/resource/service_context.go
@@ -112,8 +112,9 @@ func (r *ServiceContextResource) Read(ctx context.Context, req resource.ReadRequ
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read service context, got error: %s", err))
 		return
 	}
-	if response.ServiceContext == nil {
-		resp.Diagnostics.AddError("Client Error", "Unable to find service context, got no error")
+	if response == nil || response.ServiceContext == nil {
+		// Resource not found, remove from state
+		resp.State.RemoveResource(ctx)
 		return
 	}
 

--- a/internal/resource/service_deployment.go
+++ b/internal/resource/service_deployment.go
@@ -83,6 +83,11 @@ func (r *ServiceDeploymentResource) Read(ctx context.Context, req resource.ReadR
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read ServiceDeployment, got error: %s", err))
 		return
 	}
+	if response == nil || response.ServiceDeployment == nil {
+		// Resource not found, remove from state
+		resp.State.RemoveResource(ctx)
+		return
+	}
 
 	data.FromGet(response.ServiceDeployment, &resp.Diagnostics)
 	resp.Diagnostics.Append(resp.State.Set(ctx, data)...)

--- a/internal/resource/user.go
+++ b/internal/resource/user.go
@@ -111,9 +111,9 @@ func (r *UserResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to get user, got error: %s", err))
 		return
 	}
-
 	if response == nil || response.User == nil {
-		resp.Diagnostics.AddError("Client Error", "Unable to find user")
+		// Resource not found, remove from state
+		resp.State.RemoveResource(ctx)
 		return
 	}
 


### PR DESCRIPTION
According to the [terraform documentation](https://developer.hashicorp.com/terraform/plugin/framework/resources/read#recommendations)  for `Read` method:

> Ignore returning errors that signify the resource is no longer existent, call the response state RemoveResource() method, and return early. The next Terraform plan will recreate the resource.

I have rechecked all resources and updated the logic to do that instead of throwing error. Tested with a couple of resources, and it correctly recreates the resource without throwing error.