### PR TITLE
fix: Fix not found error handling and infrastructure stack resource

### DIFF
--- a/example/stack/main.tf
+++ b/example/stack/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     plural = {
       source  = "pluralsh/plural"
-      version = "0.0.1"
+      version = "0.2.35"
     }
   }
 }

--- a/example/stack/main.tf
+++ b/example/stack/main.tf
@@ -15,6 +15,10 @@ data "plural_cluster" "cluster" {
   handle = "mgmt"
 }
 
+data "plural_project" "default" {
+  name = "default"
+}
+
 data "plural_git_repository" "repository" {
   url = "https://github.com/zreigz/tf-hello.git"
 }
@@ -30,6 +34,7 @@ resource "plural_infrastructure_stack" "stack-full" {
   type       = "TERRAFORM"
   approval   = true
   detach     = true
+  project_id = data.plural_project.default.id
   cluster_id = data.plural_cluster.cluster.id
   repository = {
     id     = data.plural_git_repository.repository.id

--- a/internal/model/infrastructure_stack.go
+++ b/internal/model/infrastructure_stack.go
@@ -115,6 +115,7 @@ func (is *InfrastructureStackExtended) From(stack *gqlclient.InfrastructureStack
 	is.Environment = infrastructureStackEnvironmentsFrom(stack.Environment, is.Environment, ctx, d)
 	is.Bindings.From(stack.ReadBindings, stack.WriteBindings, ctx, d)
 	is.JobSpec.From(stack.JobSpec, ctx, d)
+	is.ProjectId = common.ProjectFrom(stack.Project)
 }
 
 func infrastructureStackFilesFrom(files []*gqlclient.StackFileFragment, config types.Map, d *diag.Diagnostics) types.Map {

--- a/internal/model/infrastructure_stack.go
+++ b/internal/model/infrastructure_stack.go
@@ -28,8 +28,8 @@ func (is *InfrastructureStack) From(stack *gqlclient.InfrastructureStackFragment
 	is.Name = types.StringValue(stack.Name)
 	is.Type = types.StringValue(string(stack.Type))
 	is.Approval = types.BoolPointerValue(stack.Approval)
-	is.ProjectId = common.ProjectFrom(stack.Project)
 	is.ClusterId = types.StringValue(stack.Cluster.ID)
+	is.ProjectId = common.ProjectFrom(stack.Project)
 }
 
 type InfrastructureStackExtended struct {
@@ -115,7 +115,6 @@ func (is *InfrastructureStackExtended) From(stack *gqlclient.InfrastructureStack
 	is.Environment = infrastructureStackEnvironmentsFrom(stack.Environment, is.Environment, ctx, d)
 	is.Bindings.From(stack.ReadBindings, stack.WriteBindings, ctx, d)
 	is.JobSpec.From(stack.JobSpec, ctx, d)
-	is.ProjectId = common.ProjectFrom(stack.Project)
 }
 
 func infrastructureStackFilesFrom(files []*gqlclient.StackFileFragment, config types.Map, d *diag.Diagnostics) types.Map {

--- a/internal/model/infrastructure_stack.go
+++ b/internal/model/infrastructure_stack.go
@@ -28,8 +28,8 @@ func (is *InfrastructureStack) From(stack *gqlclient.InfrastructureStackFragment
 	is.Name = types.StringValue(stack.Name)
 	is.Type = types.StringValue(string(stack.Type))
 	is.Approval = types.BoolPointerValue(stack.Approval)
-	is.ClusterId = types.StringValue(stack.Cluster.ID)
 	is.ProjectId = common.ProjectFrom(stack.Project)
+	is.ClusterId = types.StringValue(stack.Cluster.ID)
 }
 
 type InfrastructureStackExtended struct {

--- a/internal/resource/cloud_connection.go
+++ b/internal/resource/cloud_connection.go
@@ -159,11 +159,11 @@ func (r *CloudConnectionResource) Read(ctx context.Context, req resource.ReadReq
 	}
 
 	response, err := r.client.GetCloudConnection(ctx, data.Id.ValueStringPointer(), data.Name.ValueStringPointer())
-	if err != nil {
+	if err != nil && !client.IsNotFound(err) {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read cloud connection, got error: %s", err))
 		return
 	}
-	if response == nil || response.CloudConnection == nil {
+	if response == nil || response.CloudConnection == nil || client.IsNotFound(err) {
 		// Resource not found, remove from state
 		resp.State.RemoveResource(ctx)
 		return

--- a/internal/resource/cluster.go
+++ b/internal/resource/cluster.go
@@ -103,11 +103,11 @@ func (r *clusterResource) Read(ctx context.Context, req resource.ReadRequest, re
 
 	if !data.Id.IsNull() {
 		result, err := r.client.GetCluster(ctx, data.Id.ValueStringPointer())
-		if err != nil {
+		if err != nil && !client.IsNotFound(err) {
 			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read cluster, got error: %s", err))
 			return
 		}
-		if result == nil || result.Cluster == nil {
+		if result == nil || result.Cluster == nil || client.IsNotFound(err) {
 			// Resource not found, remove from state
 			resp.State.RemoveResource(ctx)
 			return
@@ -115,11 +115,11 @@ func (r *clusterResource) Read(ctx context.Context, req resource.ReadRequest, re
 		data.From(result.Cluster, ctx, &resp.Diagnostics)
 	} else if !data.Handle.IsNull() {
 		result, err := r.client.GetClusterByHandle(ctx, data.Handle.ValueStringPointer())
-		if err != nil {
+		if err != nil && !client.IsNotFound(err) {
 			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read cluster, got error: %s", err))
 			return
 		}
-		if result == nil || result.Cluster == nil {
+		if result == nil || result.Cluster == nil || client.IsNotFound(err) {
 			// Resource not found, remove from state
 			resp.State.RemoveResource(ctx)
 			return

--- a/internal/resource/git_repository.go
+++ b/internal/resource/git_repository.go
@@ -169,11 +169,11 @@ func (r *GitRepositoryResource) Read(ctx context.Context, req resource.ReadReque
 	}
 
 	response, err := r.client.GetGitRepository(ctx, data.Id.ValueStringPointer(), data.Url.ValueStringPointer())
-	if err != nil {
+	if err != nil && !client.IsNotFound(err) {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to get GitRepository, got error: %s", err))
 		return
 	}
-	if response == nil || response.GitRepository == nil {
+	if response == nil || response.GitRepository == nil || client.IsNotFound(err) {
 		// Resource not found, remove from state
 		resp.State.RemoveResource(ctx)
 		return

--- a/internal/resource/group.go
+++ b/internal/resource/group.go
@@ -111,11 +111,11 @@ func (r *GroupResource) Read(ctx context.Context, req resource.ReadRequest, resp
 	}
 
 	response, err := r.client.GetGroup(ctx, data.Name.ValueString())
-	if err != nil {
+	if err != nil && !client.IsNotFound(err) {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to get group, got error: %s", err))
 		return
 	}
-	if response == nil || response.Group == nil {
+	if response == nil || response.Group == nil || client.IsNotFound(err) {
 		// Resource not found, remove from state
 		resp.State.RemoveResource(ctx)
 		return

--- a/internal/resource/infrastructure_stack.go
+++ b/internal/resource/infrastructure_stack.go
@@ -126,7 +126,7 @@ func (r *InfrastructureStackResource) Delete(ctx context.Context, req resource.D
 
 	if data.Detach.ValueBool() {
 		_, err := r.client.DetachStack(ctx, data.Id.ValueString())
-		if err != nil {
+		if err != nil && !client.IsNotFound(err) {
 			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to detach infrastructure stack, got error: %s", err))
 			return
 		}

--- a/internal/resource/infrastructure_stack.go
+++ b/internal/resource/infrastructure_stack.go
@@ -82,11 +82,11 @@ func (r *InfrastructureStackResource) Read(ctx context.Context, req resource.Rea
 	}
 
 	response, err := r.client.GetInfrastructureStack(ctx, data.Id.ValueStringPointer(), nil)
-	if err != nil {
+	if err != nil && !client.IsNotFound(err) {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read infrastructure stack, got error: %s", err))
 		return
 	}
-	if response == nil || response.InfrastructureStack == nil {
+	if response == nil || response.InfrastructureStack == nil || client.IsNotFound(err) {
 		// Resource not found, remove from state
 		resp.State.RemoveResource(ctx)
 		return

--- a/internal/resource/infrastructure_stack_schema.go
+++ b/internal/resource/infrastructure_stack_schema.go
@@ -62,6 +62,7 @@ func (r *InfrastructureStackResource) schema() schema.Schema {
 				MarkdownDescription: "ID of the project that this stack belongs to.",
 				Computed:            true,
 				Optional:            true,
+				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"cluster_id": schema.StringAttribute{
 				Description:         "The cluster on which the stack will be applied.",

--- a/internal/resource/observability_webhook.go
+++ b/internal/resource/observability_webhook.go
@@ -122,11 +122,11 @@ func (r *ObservabilityWebhookResource) Read(ctx context.Context, req resource.Re
 	}
 
 	response, err := r.client.GetObservabilityWebhook(ctx, nil, data.Name.ValueStringPointer())
-	if err != nil {
+	if err != nil && !client.IsNotFound(err) {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read observability webhook, got error: %s", err))
 		return
 	}
-	if response == nil || response.ObservabilityWebhook == nil {
+	if response == nil || response.ObservabilityWebhook == nil || client.IsNotFound(err) {
 		// Resource not found, remove from state
 		resp.State.RemoveResource(ctx)
 		return

--- a/internal/resource/project.go
+++ b/internal/resource/project.go
@@ -155,11 +155,11 @@ func (r *ProjectResource) Read(ctx context.Context, req resource.ReadRequest, re
 	}
 
 	response, err := r.client.GetProject(ctx, data.Id.ValueStringPointer(), nil)
-	if err != nil {
+	if err != nil && !client.IsNotFound(err) {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read project, got error: %s", err))
 		return
 	}
-	if response == nil || response.Project == nil {
+	if response == nil || response.Project == nil || client.IsNotFound(err) {
 		// Resource not found, remove from state
 		resp.State.RemoveResource(ctx)
 		return

--- a/internal/resource/scm_webhook.go
+++ b/internal/resource/scm_webhook.go
@@ -128,11 +128,11 @@ func (r *SCMWebhookResource) Read(ctx context.Context, req resource.ReadRequest,
 	}
 
 	response, err := r.client.GetScmWebhook(ctx, data.Id.ValueStringPointer(), nil)
-	if err != nil {
+	if err != nil && !client.IsNotFound(err) {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read SCM webhook, got error: %s", err))
 		return
 	}
-	if response == nil || response.ScmWebhook == nil {
+	if response == nil || response.ScmWebhook == nil || client.IsNotFound(err) {
 		// Resource not found, remove from state
 		resp.State.RemoveResource(ctx)
 		return

--- a/internal/resource/service_account.go
+++ b/internal/resource/service_account.go
@@ -105,11 +105,11 @@ func (r *ServiceAccountResource) Read(ctx context.Context, req resource.ReadRequ
 	}
 
 	response, err := r.client.GetUser(ctx, data.Email.ValueString())
-	if err != nil {
+	if err != nil && !client.IsNotFound(err) {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to get service account, got error: %s", err))
 		return
 	}
-	if response == nil || response.User == nil {
+	if response == nil || response.User == nil || client.IsNotFound(err) {
 		// Resource not found, remove from state
 		resp.State.RemoveResource(ctx)
 		return

--- a/internal/resource/service_context.go
+++ b/internal/resource/service_context.go
@@ -108,11 +108,11 @@ func (r *ServiceContextResource) Read(ctx context.Context, req resource.ReadRequ
 	}
 
 	response, err := r.client.GetServiceContext(ctx, data.Name.ValueString())
-	if err != nil {
+	if err != nil && !client.IsNotFound(err) {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read service context, got error: %s", err))
 		return
 	}
-	if response == nil || response.ServiceContext == nil {
+	if response == nil || response.ServiceContext == nil || client.IsNotFound(err) {
 		// Resource not found, remove from state
 		resp.State.RemoveResource(ctx)
 		return

--- a/internal/resource/user.go
+++ b/internal/resource/user.go
@@ -107,11 +107,11 @@ func (r *UserResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 	}
 
 	response, err := r.client.GetUser(ctx, data.Email.ValueString())
-	if err != nil {
+	if err != nil && !client.IsNotFound(err) {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to get user, got error: %s", err))
 		return
 	}
-	if response == nil || response.User == nil {
+	if response == nil || response.User == nil || client.IsNotFound(err) {
 		// Resource not found, remove from state
 		resp.State.RemoveResource(ctx)
 		return

--- a/internal/resource/workbench.go
+++ b/internal/resource/workbench.go
@@ -226,11 +226,11 @@ func (r *WorkbenchResource) Read(ctx context.Context, req resource.ReadRequest, 
 	}
 
 	response, err := r.client.GetWorkbench(ctx, data.Id.ValueStringPointer(), nil)
-	if err != nil {
+	if err != nil && !client.IsNotFound(err) {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to get workbench, got error: %s", err))
 		return
 	}
-	if response == nil || response.Workbench == nil {
+	if response == nil || response.Workbench == nil || client.IsNotFound(err) {
 		// Resource not found, remove from state
 		resp.State.RemoveResource(ctx)
 		return

--- a/internal/resource/workbench_tool.go
+++ b/internal/resource/workbench_tool.go
@@ -181,11 +181,11 @@ func (r *WorkbenchToolResource) Read(ctx context.Context, req resource.ReadReque
 	}
 
 	response, err := r.client.GetWorkbenchTool(ctx, data.Id.ValueStringPointer(), nil)
-	if err != nil {
+	if err != nil && !client.IsNotFound(err) {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to get workbench tool, got error: %s", err))
 		return
 	}
-	if response == nil || response.WorkbenchTool == nil {
+	if response == nil || response.WorkbenchTool == nil || client.IsNotFound(err) {
 		// Resource not found, remove from state
 		resp.State.RemoveResource(ctx)
 		return


### PR DESCRIPTION
Added missing project ID plan modifier to avoid errors related to it during updates.

Added handling for not found error while detaching stacks. This change allowed `terraform destroy --auto-approve -refresh=false` to pass. `-refresh=false` is important as `Read` function was not prepared to handle not found errors. It only handled it when error and the resource were `nil`. 

Then fixed `Read` function not found check for all resources so `-refresh=false` is not required to avoid errors.

Related to https://github.com/pluralsh/terraform-provider-plural/pull/100.